### PR TITLE
Updated the documentation to use CucumberOptions instead of the deprecated Cucumber.Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can specify where the cucumber.json goes in your runner e.g.
      import org.junit.runner.RunWith;
 
      @RunWith(Cucumber.class)
-     @Cucumber.Options(format = {"json:path/to/cucumber.json"})
+     @CucumberOptions(plugin = {"json:path/to/cucumber.json"})
      public class SomeTest {
      }
 


### PR DESCRIPTION
Cucumber.Options was deprecated in Cucumber 1.1.5, released 2013-09-14

Cucumber.Options was removed in Cucumber 1.2.0, released 2014-10-30

More details can be found in the changelog: https://github.com/cucumber/cucumber-jvm/blob/master/CHANGELOG.md